### PR TITLE
Only increment now by fudge_factor once, not every thread

### DIFF
--- a/gmail-tickler.gs
+++ b/gmail-tickler.gs
@@ -63,6 +63,7 @@ function processThreads() {
     Logger.log("processing " + threads.length + " threads in all");
 
     var now  = new Date();
+    now.setMinutes( now.getMinutes() + FUDGE_FACTOR );
     for (var i = 0; i < threads.length; i++) {
         var info = ticklerInfo(threads[i]);
 
@@ -72,8 +73,6 @@ function processThreads() {
         }
 
         Logger.log("thread target time is " + info.target);
-
-        now.setMinutes( now.getMinutes() + FUDGE_FACTOR );
 
         if (now.getTime() >= info.target.getTime())
             untickleThread(threads[i]);


### PR DESCRIPTION
This fixes a bug that caused threads to be returned to the inbox before the desired time. It was particularly noticeable when large numbers of threads were being processed, since the FUDGE_FACTOR increments would accumulate and the emails would reapper far ahead of schedule.
