### PR TITLE
Add option to remove tickler command sub-labels on error #10

### DIFF
--- a/gmail-tickler.gs
+++ b/gmail-tickler.gs
@@ -12,12 +12,13 @@
 /*
  * 1: SET UP config options 
  */
-var EMAIL_PREFIX   = "USERNAME+tickler"; // where USERNAME@gmail.com is your regular address
-var TICKLER_LABEL  = "tickler";          
-var FINISH_LABEL   = "tickler/finished"; // label name, or `false`
-var ERROR_LABEL    = "tickler/error";    // label name, or `false`
-var MARK_UNREAD    = true;               // mark unread when restoring a message to the inbox
-var EMAIL_ERRORS   = true;               // report error message as email reply within thread
+var EMAIL_PREFIX     = "USERNAME+tickler"; // where USERNAME@gmail.com is your regular address
+var TICKLER_LABEL    = "tickler";
+var FINISH_LABEL     = "tickler/finished"; // label name, or `false`
+var ERROR_LABEL      = "tickler/error";    // label name, or `false`
+var REMOVE_CONFLICTS = false;              // remove conflicting labels when an error is encountered
+var MARK_UNREAD      = true;               // mark unread when restoring a message to the inbox
+var EMAIL_ERRORS     = true;               // report error message as email reply within thread
 
 var CLEANUP_LABELS = true;               // remove empty tickler-command labels
 var EXEMPT_LABELS  =                     // labels to have around even if empty
@@ -346,8 +347,15 @@ function errorThread(t, info) {
 
     if (DRY_RUN) return;
 
-    t.moveToInbox();
+    if (REMOVE_CONFLICTS) {
+        var labels = getTicklerCmdLabels(t);
+        for (var i=0; i<labels.length; i++) {
+            t.removeLabel(labels[i]);
+        }
+    }
+
     GmailApp.getUserLabelByName(TICKLER_LABEL).removeFromThread(t);
+    t.moveToInbox();
 
     if (info.msg && EMAIL_ERRORS) {
         var err;


### PR DESCRIPTION
This is useful for email clients that do not display the labels applied to a message, or make it easier to add labels than to remove them.

From the associated issue https://github.com/rosulek/gmail-tickler/issues/10:

> While some users might prefer to see the labels that were in conflict, most of the time I can easily remember/re-decide until when I want to snooze the thread. The current behavior is particularly frustrating on email clients (such as Outlook on iOS) that don't show the labels that a thread currently has. If I snooze a thread to time A, and then a new email in that thread bumps it back to my inbox, then I may snooze it to time B without realizing that it already has the label for time A. This will cause it to mysteriously appear in my inbox again and again, no matter how many times I try to snooze it. If the Tickler removed the conflicting labels, then the snooze would again succeed the third time.
