### PR TITLE
Fail gracefully for threads that don't have messages

### DIFF
--- a/gmail-tickler.gs
+++ b/gmail-tickler.gs
@@ -67,7 +67,10 @@ function processThreads() {
     for (var i = 0; i < threads.length; i++) {
         var info = ticklerInfo(threads[i]);
 
-        if (! info || ! info.target || ! info.target['getTime']) {
+        if (! info)
+            continue;
+
+        if (! info.target || ! info.target['getTime']) {
             errorThread(threads[i], info);
             continue;
         }
@@ -122,8 +125,10 @@ function getTicklerCmdLabels(t) {
 
 function ticklerInfo(t) {
     var msgs = t.getMessages();
-    if (!msgs)
+    if (!msgs) {
+        Logger.log("no messages found in thread `" + t.getFirstMessageSubject() + "`");
         return false;
+    }
     var result = { baseline: msgs[msgs.length-1].getDate() };
 
     Logger.log("extracting info from thread `" + t.getFirstMessageSubject() + "`");

--- a/gmail-tickler.gs
+++ b/gmail-tickler.gs
@@ -67,7 +67,7 @@ function processThreads() {
     for (var i = 0; i < threads.length; i++) {
         var info = ticklerInfo(threads[i]);
 
-        if (! info.target || ! info.target['getTime']) {
+        if (! info || ! info.target || ! info.target['getTime']) {
             errorThread(threads[i], info);
             continue;
         }
@@ -122,6 +122,8 @@ function getTicklerCmdLabels(t) {
 
 function ticklerInfo(t) {
     var msgs = t.getMessages();
+    if (!msgs)
+        return false;
     var result = { baseline: msgs[msgs.length-1].getDate() };
 
     Logger.log("extracting info from thread `" + t.getFirstMessageSubject() + "`");


### PR DESCRIPTION
I occasionally get email notifications of errors in `processThreads` that say `TypeError: Cannot read property "length" from null. (line 134, file "Code")`. I haven't been able to figure out what's causing this, and there's nothing in [the documentation](https://developers.google.com/apps-script/reference/gmail/gmail-thread#getMessages%28%29) about why getMessages would return `null` for a thread, but it's still better not to crash the entire script when it _does_ happen, since that could delay/confuse the untickling of other threads.

(My personal script has a few extra lines of config, hence the slight mismatch in the line numbers.)
