### PR TITLE
Solve relative baseline problem by converting/renaming labels

### DIFF
--- a/gmail-tickler.gs
+++ b/gmail-tickler.gs
@@ -264,7 +264,7 @@ function parseDate(s, baseline) {
             s = s.substr(matches[0].length);
         }
 
-        matches = s.match(/^(?:at\s*)?(noon|midnight|([1-9]|1[012])(?:([0-5]\d))?([ap]m?)|([01]?\d|2[0-3])([0-5]\d)(?![apAP0-9]))/i);
+        matches = s.match(/^(?:at\s*)?(noon|midnight|([1-9]|1[012])\:?(?:([0-5]\d))?([ap]m?)|([01]?\d|2[0-3])\:?([0-5]\d)(?![apAP0-9]))/i);
         if (matches) {
             if (timeReason) {
                 conflicts = [timeReason, matches[0]];

--- a/gmail-tickler.gs
+++ b/gmail-tickler.gs
@@ -242,8 +242,9 @@ function parseDate(s, baseline) {
             s = s.substr(matches[0].length);
         }
 
-        matches = s.match(/^(?:on\s*)?(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|june?|july?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s*(\d+)/i);
+        matches = s.match(/^(?:on\s*)?(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|june?|july?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s*(\d+)\,?\s*(\d{4})?/i);
         if (matches) {
+            var year = parseInt(matches[3], 10)
             var mon = MONTHS[ matches[1].substr(0,3).toLowerCase() ];
             var day = parseInt(matches[2], 10)
 
@@ -252,8 +253,11 @@ function parseDate(s, baseline) {
                 break;
             }
             dateReason = matches[0];
-            ifPast = "y";
 
+            if (isNaN(year))
+                ifPast = "y";
+            else
+                theDate.setFullYear(year);
             theDate.setMonth(mon);
             theDate.setDate(day);
 

--- a/gmail-tickler.gs
+++ b/gmail-tickler.gs
@@ -25,7 +25,7 @@ var EXEMPT_LABELS  =                     // labels to have around even if empty
     [ "tomorrow", "sun", "mon", "tue",
       "wed", "thu", "fri", "sat",
       "1wk", "2wks"
-    ].map( function(x){ return TICKLER_LABEL + "/" + x });
+    ].map( function(x){ return TICKLER_LABEL + "/ " + x });
 
 
 var DEFAULT_TIME   = [8, 0, 0, 0];       // for dates that don't specify a time-of-day,
@@ -178,6 +178,7 @@ function parseDate(s, baseline) {
 
     Logger.log("parsing tickler command `" + s + "` with baseline = " + baseline);
 
+    s = s.trim();  // to account for the prefix on exempt labels
     var charsRemain = s.length + 1;
     while (charsRemain && charsRemain != s.length) {
         charsRemain = s.length;
@@ -340,6 +341,7 @@ function convertCmdLabels(t, theDate) {
     else
         cmd = Utilities.formatDate(theDate, Session.getScriptTimeZone(), "haaa' on 'MMM dd, yyyy");
 
+    cmd = cmd.toLowerCase();
     Logger.log("converting labels to `" + cmd + "` for thread `" + t.getFirstMessageSubject() + "`");
     var label = TICKLER_LABEL + "/" + cmd;
 

--- a/gmail-tickler.gs
+++ b/gmail-tickler.gs
@@ -287,6 +287,7 @@ function parseDate(s, baseline) {
                 minute = parseInt(matches[6], 10);
             }   
             
+            ifPast = "d";
             theDate.setHours(hour, minute, 0, 0);
             s = s.substr(matches[0].length);
             continue;
@@ -310,6 +311,8 @@ function parseDate(s, baseline) {
             theDate.setFullYear( theDate.getFullYear() + 1);
         else if (ifPast == "w")
             theDate.setDate( theDate.getDate() + 7 );
+        else if (ifPast == "d")
+            theDate.setDate( theDate.getDate() + 1 );
         else
             return "illegal date in past";
     }


### PR DESCRIPTION
**Do not merge this yet.** I'm not quite done, but wanted to make the PR now and get feedback sooner rather than later. It might be a bit easier to look commit-by-commit. 

The general idea, as described in https://github.com/rosulek/gmail-tickler/issues/6#issuecomment-173088998, is to use the script's runtime as the baseline and convert/rename all tickler labels so that they fully specify the intended timestamp.

A few things still to do:
- [x] More efficient application/removal of labels. This might be a bit tricky, but the script probably should not be removing and re-applying the same labels to every non-untickled thread every time it runs. (I hit the quota yesterday afternoon, possibly because of testing, but it would still be better to have some room to breath. I suspect the Gmail API calls are the slowest part.)
- [ ] Add configuration options for the format of the absolute timestamp labels.
- [ ] Maybe improve handling of ambiguous cases when the script runs very close to the interpreted time of a non-absolute label, possibly using the `FUDGE_FACTOR` and/or considering these cases as errors.
- [ ] Consider how this interacts with email-based tickling. Should this whole strategy be optional?
- [ ] Update the readme.
