### PR TITLE
Loop over labels 2x to restore just-tickled threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Google developers wrote [Gmail Snooze](http://googleappsdeveloper.blogspot.com/2
 
 11 Oct 2016: intuitive handling of relative dates in labels [idea suggested by @lehrblogger], other refactorings
 
+27 Nov 2016: bugfix [thanks, @lehrblogger]
+
 ## To do list:
 
 * (Figure out how to) Bundle the script as a [web app](https://developers.google.com/apps-script/execution_web_apps) so installation is easy for everyone.

--- a/gmail-tickler.gs
+++ b/gmail-tickler.gs
@@ -78,23 +78,27 @@ function setup() {
  */
 function ticklerMain() {
     Logger.clear();
+    processLabels(false);
+    processLabels(true);
+}
 
+// don't go beyond this point! ... or do... I'm a code comment, not a cop.
+////////////////////////////////////////////////////////////////////////////
+
+function processLabels(restoreOnly) {  // run a second time to restore just-tickled threads
     var labels = GmailApp.getUserLabels();
     for (var i=0; i < labels.length; i++) {
         var lbl = labels[i];
         var action = labelAction(lbl);
         if (action == "ignore") continue;
 
-        Logger.log("ticklerMain: label " + lbl.getName() + " ==> action = " + action);
+        Logger.log("ticklerMain(restoreOnly=" + restoreOnly + "): label " + lbl.getName() + " ==> action = " + action);
 
-        if (action == "tickle")  tickleLabel(lbl);
-        if (action == "restore") restoreLabel(lbl);
-        if (action == "email")   emailTickleLabel(lbl);
+        if (action == "tickle" && !restoreOnly) tickleLabel(lbl);
+        if (action == "restore")                restoreLabel(lbl);
+        if (action == "email" && !restoreOnly)  emailTickleLabel(lbl);
     }
 }
-
-// don't go beyond this point! ... or do... I'm a code comment, not a cop.
-////////////////////////////////////////////////////////////////////////////
 
 function labelAction(lbl) {
     var name = lbl.getName();

--- a/gmail-tickler.gs
+++ b/gmail-tickler.gs
@@ -2,7 +2,7 @@
  * Gmail Tickler, a Google Apps script
  * written by Mike Rosulek, rosulekm@eecs.oregonstate.edu
  *
- * Revision: 9 Oct 2016
+ * Revision: 27 Nov 2016
  *
  * Made available under the MIT license. See the license and instructions at:
  *

--- a/gmail-tickler.gs
+++ b/gmail-tickler.gs
@@ -92,7 +92,7 @@ function processLabels(restoreOnly) {  // run a second time to restore just-tick
         var action = labelAction(lbl);
         if (action == "ignore") continue;
 
-        Logger.log("ticklerMain(restoreOnly=" + restoreOnly + "): label " + lbl.getName() + " ==> action = " + action);
+        Logger.log("processLabels(restoreOnly=" + restoreOnly + "): label " + lbl.getName() + " ==> action = " + action);
 
         if (action == "tickle" && !restoreOnly) tickleLabel(lbl);
         if (action == "restore")                restoreLabel(lbl);


### PR DESCRIPTION
Otherwise, threads that were converted from a command to a tickle label by the current execution of the script won't also get restored if it's within the appropriate time window.

This isn't a particularly elegant solution, but minimizes complexity added elsewhere. It does mean the script calls `GmailApp.getUserLabels()` an extra time on every execution, and also `lbl.getThreads()` for each label matching `TICKLE.label_prefix`, but I'm inclined to address performance issues once they occur with the new implementation.

